### PR TITLE
Updated package and freshness for `satisfaction_rating`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ target/
 dbt_modules/
 logs/
 .DS_Store
+
+# Pycharm
+.idea

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Zendesk Support (Source)
 
-This package models Zendesk Support data from [Fivetran's connector](https://fivetran.com/docs/applications/zendesk). It uses data in the format described by [this ERD](https://docs.google.com/presentation/d/1AQv77L9WlDXqRS0gkdQTmg1HSUo-Znlcoq7CHg0JrP8).
+This package models Zendesk Support data from [Fivetran's connector](https://fivetran.com/docs/applications/zendesk). It uses data in the format described by [this ERD](https://fivetran.com/docs/applications/zendesk#schemainformation).
 
 This package enriches your Fivetran data by doing the following:
 

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -3,7 +3,7 @@ config-version: 2
 name: 'zendesk_source'
 version: '0.0.1'
 
-require-dbt-version: '>=0.18.0'
+require-dbt-version: [">=0.18.0", "<0.19.0"]
 
 models:
     zendesk_source:

--- a/models/src_zendesk.yml
+++ b/models/src_zendesk.yml
@@ -80,6 +80,9 @@ sources:
           element of ticket workflow; support agents are organized into Groups and tickets can be assigned to a Group
           only, or to an assigned agent within a Group. A ticket can never be assigned to an agent without also being 
           assigned to a Group.
+        identifier: "{%- if target.type == 'snowflake' -%} GROUP {%- else -%} group {%- endif -%}"
+        quoting:
+          identifier: true
         freshness: null
         columns:
           - name: id

--- a/models/src_zendesk.yml
+++ b/models/src_zendesk.yml
@@ -244,6 +244,7 @@ sources:
       - name: alert_recipient
 
       - name: article
+        freshness: null  # do not check freshness for this table
 
       - name: call_metric
 

--- a/models/src_zendesk.yml
+++ b/models/src_zendesk.yml
@@ -254,6 +254,7 @@ sources:
       - name: group_member
 
       - name: satisfaction_rating
+        freshness: null  # do not check freshness for this table
 
       - name: ticket_alert
 

--- a/models/stg_zendesk_schedule.sql
+++ b/models/stg_zendesk_schedule.sql
@@ -16,7 +16,7 @@ with base as (
       created_at
       
     from base
-    where not _fivetran_deleted
+    where not coalesce(_fivetran_deleted, false)
 
 )
 


### PR DESCRIPTION
this PR does three things:
- updates the branch to be even with `fivetran/dbt_zendesk_source`
- skips the freshness of `satisfaction_rating` which hasn't been updated since `2020-08-19`
- skips the freshness of `article`

